### PR TITLE
Ignore rmf_demos_maps and downstream dependencies

### DIFF
--- a/humble.ignored
+++ b/humble.ignored
@@ -1,0 +1,3 @@
+rmf_demos
+rmf_demos_gz
+rmf_demos_maps

--- a/jazzy.ignored
+++ b/jazzy.ignored
@@ -1,0 +1,3 @@
+rmf_demos
+rmf_demos_gz
+rmf_demos_maps


### PR DESCRIPTION
This PR adds `.ignored` as recommended in https://github.com/ros2/ros_buildfarm_config/pull/315#issuecomment-2591773332.

We still prefer to bloom these packages for Rolling so that we can test out approaches for distributing maps/assets.